### PR TITLE
* chore(go.mod): update dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,22 @@ module github.com/Bit-Bridge-Source/BitBridge-CommonService-Go
 
 go 1.21.0
 
-require golang.org/x/crypto v0.14.0
+require (
+	github.com/gofiber/fiber/v2 v2.50.0
+	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/hashicorp/vault/api v1.10.0
+	go.mongodb.org/mongo-driver v1.12.1
+	golang.org/x/crypto v0.14.0
+	google.golang.org/grpc v1.58.3
+)
 
 require (
+	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/google/uuid v1.3.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
@@ -17,15 +27,27 @@ require (
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.5 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/hashicorp/vault/api v1.10.0 // indirect
+	github.com/klauspost/compress v1.16.7 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasthttp v1.50.0 // indirect
+	github.com/valyala/tcplisten v1.0.0 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.1.2 // indirect
+	github.com/xdg-go/stringprep v1.0.4 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
 	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231012201019-e917dd12ba7a // indirect
-	google.golang.org/grpc v1.58.3 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 )


### PR DESCRIPTION
* - Update golang.org/x/crypto from v0.14.0 to v0.14.0
* - Add github.com/gofiber/fiber/v2 v2.50.0
* - Add github.com/golang-jwt/jwt v3.2.2+incompatible
* - Add github.com/hashicorp/vault/api v1.10.0
* - Add go.mongodb.org/mongo-driver v1.12.1
* - Add github.com/andybalholm/brotli v1.0.5
* - Add github.com/golang/snappy v0.0.1
* - Add github.com/google/uuid v1.3.1
* - Add github.com/klauspost/compress v1.16.7
* - Add github.com/mattn/go-colorable v0.1.13
* - Add github.com/mattn